### PR TITLE
fix: allow users to overwrite the lib and lib_version properties

### DIFF
--- a/src/main/java/net/hollowcube/posthog/PostHogClientImpl.java
+++ b/src/main/java/net/hollowcube/posthog/PostHogClientImpl.java
@@ -25,9 +25,9 @@ import static net.hollowcube.posthog.FeatureFlagState.REMOTE_EVAL_NOT_ALLOWED;
 import static net.hollowcube.posthog.PostHogNames.*;
 
 public final class PostHogClientImpl implements PostHogClient {
-    private static final String LIBRARY_NAME = "github.com/hollow-cube/posthog-java";
-    private static final String LIBRARY_VERSION = "1.0.0";
-    private static final String USER_AGENT = String.format("%s/%s", LIBRARY_NAME, LIBRARY_VERSION);
+    private static final String DEFAULT_LIBRARY_NAME = "github.com/hollow-cube/posthog-java";
+    private static final String DEFAULT_LIBRARY_VERSION = "1.0.0";
+    private static final String USER_AGENT = String.format("%s/%s", DEFAULT_LIBRARY_NAME, DEFAULT_LIBRARY_VERSION);
     private static final int STACKTRACE_FRAME_LIMIT = 100;
 
     private static final Logger log = LoggerFactory.getLogger(PostHogClientImpl.class);
@@ -75,8 +75,8 @@ public final class PostHogClientImpl implements PostHogClient {
         this.personalApiKey = personalApiKey;
 
         this.defaultEventProperties = gson.toJsonTree(defaultEventProperties).getAsJsonObject();
-        this.defaultEventProperties.addProperty("$lib", LIBRARY_NAME);
-        this.defaultEventProperties.addProperty("$lib_version", LIBRARY_VERSION);
+        this.setPropertyIfAbsent(this.defaultEventProperties, LIB, DEFAULT_LIBRARY_NAME);
+        this.setPropertyIfAbsent(this.defaultEventProperties, LIB_VERSION, DEFAULT_LIBRARY_VERSION);
         this.eventBatchTimeout = eventBatchTimeout;
 
         // Always enable local evaluation with personal api key.
@@ -447,5 +447,11 @@ public final class PostHogClientImpl implements PostHogClient {
             stackFrames.add(frame);
         }
         return stackFrames;
+    }
+
+    private void setPropertyIfAbsent(@NotNull JsonObject object, @NotNull String key, @NotNull String value) {
+        if (!object.has(key)) {
+            object.addProperty(key, value);
+        }
     }
 }

--- a/src/main/java/net/hollowcube/posthog/PostHogNames.java
+++ b/src/main/java/net/hollowcube/posthog/PostHogNames.java
@@ -21,6 +21,9 @@ public final class PostHogNames {
     public static final String GROUP_KEY = "$groupkey";
     public static final String GROUP_SET = "$group_set";
 
+    public static final String LIB = "$lib";
+    public static final String LIB_VERSION = "$lib_version";
+
     // This group is typically autocaptured by other SDKs, see here
     // https://posthog.com/docs/product-analytics/autocapture
     public static final String AUTO_CAPTURE = "$autocapture";


### PR DESCRIPTION
We use the library to distinguish the submitting entity (e.g. microservice, proxy, etc.) but the way because values are set by this library after the defaults object is created it's not possible to override them without setting it in every method call.