### PR TITLE
fix: NullPointerException on first feature flag retrieval

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,10 +10,10 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v3
       - name: Set up JDK 21
-        uses: actions/setup-graalvm@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: '21'
           distribution: 'graalvm'
+          java-version: '21'
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Build

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,11 +9,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v3
-      - name: Setup Java
-        uses: actions/setup-java@v4
+      - name: Set up JDK 21
+        uses: actions/setup-graalvm@v1
         with:
-          distribution: temurin
-          java-version: 21
+          java-version: '21'
+          distribution: 'graalvm'
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21
-        uses: actions/setup-graalvm@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: '21'
           distribution: 'graalvm'
+          java-version: '21'
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Publish to Sonatype

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21
-        uses: actions/setup-java@v2
+        uses: actions/setup-graalvm@v1
         with:
           java-version: '21'
-          distribution: 'temurin'
+          distribution: 'graalvm'
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Publish to Sonatype

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,6 @@ java {
 
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
-        vendor.set(JvmVendorSpec.GRAAL_VM)
         nativeImageCapable = true
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ java {
 
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
+        vendor.set(JvmVendorSpec.GRAAL_VM)
         nativeImageCapable = true
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,1 @@
 rootProject.name = "posthog-java"
-
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
-}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,5 @@
 rootProject.name = "posthog-java"
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,5 @@
 rootProject.name = "posthog-java"
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}

--- a/src/main/java/net/hollowcube/posthog/PostHogClientImpl.java
+++ b/src/main/java/net/hollowcube/posthog/PostHogClientImpl.java
@@ -86,17 +86,18 @@ public final class PostHogClientImpl implements PostHogClient {
         this.setPropertyIfAbsent(this.defaultEventProperties, LIB_VERSION, DEFAULT_LIBRARY_VERSION);
         this.eventBatchTimeout = eventBatchTimeout;
 
+        this.allowRemoteFeatureFlagEvaluation = allowRemoteFeatureFlagEvaluation;
+        this.sendFeatureFlagEvents = sendFeatureFlagEvents;
+        this.featureFlagsRequestTimeout = featureFlagsRequestTimeout;
+
+        this.exceptionMiddleware = exceptionMiddleware;
+
         // Always enable local evaluation with personal api key.
         if (this.personalApiKey != null) {
             this.featureFlagFetchTimer = new Timer(this::loadRemoteFeatureFlags, featureFlagsPollingInterval);
         } else if (!allowRemoteFeatureFlagEvaluation) {
             throw new IllegalArgumentException("Personal API key is required when remote feature flag evaluation is disabled");
         } else this.featureFlagFetchTimer = null;
-        this.allowRemoteFeatureFlagEvaluation = allowRemoteFeatureFlagEvaluation;
-        this.sendFeatureFlagEvents = sendFeatureFlagEvents;
-        this.featureFlagsRequestTimeout = featureFlagsRequestTimeout;
-
-        this.exceptionMiddleware = exceptionMiddleware;
     }
 
     @Override


### PR DESCRIPTION
Fixes an NPE on the first retrieval of feature flags caused by certain parameters (primarily `featureFlagsRequestTimeout`) being set after the first request is made.

Additionally, improves first use experience by:
- Adding `org.gradle.toolchains.foojay-resolver-convention` which automatically resolves and downloads the required toolchain JAR for building, so a user doesn't have to install Graal Java 21 on their pc.
- Specifying toolchain vendor as `GRAAL_VM` so the foojay resolver downloads a graal java build.