### PR TITLE
feat: allow blocking until local FFs loaded

### DIFF
--- a/src/main/java/net/hollowcube/posthog/PostHog.java
+++ b/src/main/java/net/hollowcube/posthog/PostHog.java
@@ -43,7 +43,7 @@ public final class PostHog {
      * Capture an event with the given name for the given distinct ID with no properties.
      *
      * @param distinctId Unique ID of the target in your database. May not be empty.
-     * @param event Name of the event. May not be empty.
+     * @param event      Name of the event. May not be empty.
      */
     public static void capture(@NotNull String distinctId, @NotNull String event) {
         getClient().capture(distinctId, event);
@@ -53,7 +53,7 @@ public final class PostHog {
      * Capture an event with the given name for the given distinct ID with the provided properties.
      *
      * @param distinctId Unique ID of the target in your database. May not be empty.
-     * @param event Name of the event. May not be empty.
+     * @param event      Name of the event. May not be empty.
      * @param properties Event properties
      */
     public static void capture(@NotNull String distinctId, @NotNull String event, @NotNull Map<String, Object> properties) {
@@ -66,7 +66,7 @@ public final class PostHog {
      * <p>The object must be serializable to a JSON object via Gson (not primitive or array)</p>
      *
      * @param distinctId Unique ID of the target in your database. May not be empty.
-     * @param event Name of the event. May not be empty.
+     * @param event      Name of the event. May not be empty.
      * @param properties Event object data
      */
     public static void capture(@NotNull String distinctId, @NotNull String event, @NotNull Object properties) {
@@ -76,8 +76,8 @@ public final class PostHog {
     /**
      * Link the given properties with the person profile of the user (distinct id).
      *
-     * @param distinctId Unique ID of the target in your database. May not be empty.
-     * @param properties Properties to set (including overwriting previous values) on the person profile
+     * @param distinctId        Unique ID of the target in your database. May not be empty.
+     * @param properties        Properties to set (including overwriting previous values) on the person profile
      * @param propertiesSetOnce Properties to set only if missing on the person profile
      */
     public static void identify(@NotNull String distinctId, @Nullable Map<String, Object> properties, @Nullable Map<String, Object> propertiesSetOnce) {
@@ -89,8 +89,8 @@ public final class PostHog {
      *
      * <p>The objects must be serializable to a JSON object via Gson (not primitive or array)</p>
      *
-     * @param distinctId Unique ID of the target in your database. May not be empty.
-     * @param properties Properties to set (including overwriting previous values) on the person profile
+     * @param distinctId        Unique ID of the target in your database. May not be empty.
+     * @param properties        Properties to set (including overwriting previous values) on the person profile
      * @param propertiesSetOnce Properties to set only if missing on the person profile
      */
     public static void identify(@NotNull String distinctId, @Nullable Object properties, @Nullable Object propertiesSetOnce) {
@@ -122,8 +122,8 @@ public final class PostHog {
     /**
      * Set the given properties with the person profile of the user (distinct id).
      *
-     * @param distinctId Unique ID of the target in your database. May not be empty.
-     * @param properties Properties to set (including overwriting previous values) on the person profile
+     * @param distinctId        Unique ID of the target in your database. May not be empty.
+     * @param properties        Properties to set (including overwriting previous values) on the person profile
      * @param propertiesSetOnce Properties to set only if missing on the person profile
      */
     public static void set(@NotNull String distinctId, @Nullable Map<String, Object> properties, @Nullable Map<String, Object> propertiesSetOnce) {
@@ -135,8 +135,8 @@ public final class PostHog {
      *
      * <p>The objects must be serializable to a JSON object via Gson (not primitive or array)</p>
      *
-     * @param distinctId Unique ID of the target in your database. May not be empty.
-     * @param properties Properties to set (including overwriting previous values) on the person profile
+     * @param distinctId        Unique ID of the target in your database. May not be empty.
+     * @param properties        Properties to set (including overwriting previous values) on the person profile
      * @param propertiesSetOnce Properties to set only if missing on the person profile
      */
     public static void set(@NotNull String distinctId, @Nullable Object properties, @Nullable Object propertiesSetOnce) {
@@ -169,7 +169,7 @@ public final class PostHog {
      * Alias the given distinct ID to the given alias.
      *
      * @param distinctId Unique ID of the target in your database. May not be empty.
-     * @param alias Alias to set for the distinct ID. May not be empty.
+     * @param alias      Alias to set for the distinct ID. May not be empty.
      */
     public static void alias(@NotNull String distinctId, @NotNull String alias) {
         getClient().alias(distinctId, alias);
@@ -178,8 +178,8 @@ public final class PostHog {
     /**
      * Assign the given properties to the given group (type &amp; key).
      *
-     * @param type Group type. Must not be empty
-     * @param key Group key. Must not be empty
+     * @param type       Group type. Must not be empty
+     * @param key        Group key. Must not be empty
      * @param properties Properties to set (including overwriting previous values) on the group
      */
     public static void groupIdentify(@NotNull String type, @NotNull String key, @NotNull Map<String, Object> properties) {
@@ -191,8 +191,8 @@ public final class PostHog {
      *
      * <p>The object must be serializable to a JSON object via Gson (not primitive or array)</p>
      *
-     * @param type Group type. Must not be empty
-     * @param key Group key. Must not be empty
+     * @param type       Group type. Must not be empty
+     * @param key        Group key. Must not be empty
      * @param properties Properties to set (including overwriting previous values) on the group
      */
     public static void groupIdentify(@NotNull String type, @NotNull String key, @NotNull Object properties) {
@@ -212,7 +212,7 @@ public final class PostHog {
     /**
      * Check if the given feature flag is enabled for the given distinct ID.
      *
-     * @param key Feature flag key
+     * @param key        Feature flag key
      * @param distinctId Unique ID of the target in your database. May not be empty
      * @return True if the feature flag is enabled for the given distinct ID, false otherwise
      */
@@ -223,9 +223,9 @@ public final class PostHog {
     /**
      * Check if the given feature flag is enabled for the given distinct ID with extra context.
      *
-     * @param key Feature flag key
+     * @param key        Feature flag key
      * @param distinctId Unique ID of the target in your database. May not be empty
-     * @param context Extra context to pass to the feature flag evaluation
+     * @param context    Extra context to pass to the feature flag evaluation
      * @return True if the feature flag is enabled for the given distinct ID, false otherwise
      */
     public static boolean isFeatureEnabled(@NotNull String key, @NotNull String distinctId, @Nullable FeatureFlagContext context) {
@@ -235,7 +235,7 @@ public final class PostHog {
     /**
      * Get the feature flag state for the given distinct ID.
      *
-     * @param key Feature flag key
+     * @param key        Feature flag key
      * @param distinctId Unique ID of the target in your database. May not be empty
      * @return Feature flag state
      */
@@ -246,9 +246,9 @@ public final class PostHog {
     /**
      * Get the feature flag state for the given distinct ID with extra context.
      *
-     * @param key Feature flag key
+     * @param key        Feature flag key
      * @param distinctId Unique ID of the target in your database. May not be empty
-     * @param context Extra context to pass to the feature flag evaluation
+     * @param context    Extra context to pass to the feature flag evaluation
      * @return Feature flag state
      */
     public static @NotNull FeatureFlagState getFeatureFlag(@NotNull String key, @NotNull String distinctId, @Nullable FeatureFlagContext context) {
@@ -271,7 +271,7 @@ public final class PostHog {
      * Get all feature flags for the given distinct ID with extra context.
      *
      * @param distinctId Unique ID of the target in your database. May not be empty
-     * @param context Extra context to pass to the feature flag evaluation
+     * @param context    Extra context to pass to the feature flag evaluation
      * @return Feature flag states
      */
     public static @NotNull FeatureFlagStates getAllFeatureFlags(@NotNull String distinctId, @Nullable FeatureFlagContext context) {
@@ -286,6 +286,21 @@ public final class PostHog {
      */
     public static void reloadFeatureFlags() {
         getClient().reloadFeatureFlags();
+    }
+
+    /**
+     * Blocks until local feature flags have been fetched, or the timeout is reached.
+     *
+     * <p>This is useful during application startup to ensure feature flags are available
+     * before accepting requests. If it fails, local evals are disabled until it re-fetches (and it succeeds).
+     *
+     * @param timeout Maximum time to wait for the fetch to complete
+     * @return true if feature flags were successfully loaded, false if the fetch failed or timed out
+     * @throws UnsupportedOperationException if local feature flag evaluation is not enabled
+     */
+    @Blocking
+    public static boolean awaitFeatureFlags(@NotNull Duration timeout) {
+        return getClient().awaitFeatureFlags(timeout);
     }
 
     // Exceptions

--- a/src/main/java/net/hollowcube/posthog/PostHog.java
+++ b/src/main/java/net/hollowcube/posthog/PostHog.java
@@ -299,8 +299,8 @@ public final class PostHog {
      * @throws UnsupportedOperationException if local feature flag evaluation is not enabled
      */
     @Blocking
-    public static boolean awaitFeatureFlags(@NotNull Duration timeout) {
-        return getClient().awaitFeatureFlags(timeout);
+    public static boolean loadRemoteFeatureFlags(@NotNull Duration timeout) {
+        return getClient().loadRemoteFeatureFlags(timeout);
     }
 
     // Exceptions

--- a/src/main/java/net/hollowcube/posthog/PostHogClient.java
+++ b/src/main/java/net/hollowcube/posthog/PostHogClient.java
@@ -49,7 +49,7 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
      * Capture an event with the given name for the given distinct ID with no properties.
      *
      * @param distinctId Unique ID of the target in your database. May not be empty.
-     * @param event Name of the event. May not be empty.
+     * @param event      Name of the event. May not be empty.
      */
     default void capture(@NotNull String distinctId, @NotNull String event) {
         capture(distinctId, event, Map.of());
@@ -59,7 +59,7 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
      * Capture an event with the given name for the given distinct ID with the provided properties.
      *
      * @param distinctId Unique ID of the target in your database. May not be empty.
-     * @param event Name of the event. May not be empty.
+     * @param event      Name of the event. May not be empty.
      * @param properties Event properties
      */
     default void capture(@NotNull String distinctId, @NotNull String event, @NotNull Map<String, Object> properties) {
@@ -72,7 +72,7 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
      * <p>The object must be serializable to a JSON object via Gson (not primitive or array)</p>
      *
      * @param distinctId Unique ID of the target in your database. May not be empty.
-     * @param event Name of the event. May not be empty.
+     * @param event      Name of the event. May not be empty.
      * @param properties Event object data
      */
     void capture(@NotNull String distinctId, @NotNull String event, @NotNull Object properties);
@@ -80,8 +80,8 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
     /**
      * Link the given properties with the person profile of the user (distinct id).
      *
-     * @param distinctId Unique ID of the target in your database. May not be empty.
-     * @param properties Properties to set (including overwriting previous values) on the person profile
+     * @param distinctId        Unique ID of the target in your database. May not be empty.
+     * @param properties        Properties to set (including overwriting previous values) on the person profile
      * @param propertiesSetOnce Properties to set only if missing on the person profile
      */
     default void identify(@NotNull String distinctId, @Nullable Map<String, Object> properties, @Nullable Map<String, Object> propertiesSetOnce) {
@@ -96,8 +96,8 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
      *
      * <p>The objects must be serializable to a JSON object via Gson (not primitive or array)</p>
      *
-     * @param distinctId Unique ID of the target in your database. May not be empty.
-     * @param properties Properties to set (including overwriting previous values) on the person profile
+     * @param distinctId        Unique ID of the target in your database. May not be empty.
+     * @param properties        Properties to set (including overwriting previous values) on the person profile
      * @param propertiesSetOnce Properties to set only if missing on the person profile
      */
     default void identify(@NotNull String distinctId, @Nullable Object properties, @Nullable Object propertiesSetOnce) {
@@ -136,8 +136,8 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
     /**
      * Set the given properties with the person profile of the user (distinct id).
      *
-     * @param distinctId Unique ID of the target in your database. May not be empty.
-     * @param properties Properties to set (including overwriting previous values) on the person profile
+     * @param distinctId        Unique ID of the target in your database. May not be empty.
+     * @param properties        Properties to set (including overwriting previous values) on the person profile
      * @param propertiesSetOnce Properties to set only if missing on the person profile
      */
     default void set(@NotNull String distinctId, @Nullable Map<String, Object> properties, @Nullable Map<String, Object> propertiesSetOnce) {
@@ -152,8 +152,8 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
      *
      * <p>The objects must be serializable to a JSON object via Gson (not primitive or array)</p>
      *
-     * @param distinctId Unique ID of the target in your database. May not be empty.
-     * @param properties Properties to set (including overwriting previous values) on the person profile
+     * @param distinctId        Unique ID of the target in your database. May not be empty.
+     * @param properties        Properties to set (including overwriting previous values) on the person profile
      * @param propertiesSetOnce Properties to set only if missing on the person profile
      */
     default void set(@NotNull String distinctId, @Nullable Object properties, @Nullable Object propertiesSetOnce) {
@@ -193,7 +193,7 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
      * Alias the given distinct ID to the given alias.
      *
      * @param distinctId Unique ID of the target in your database. May not be empty.
-     * @param alias Alias to set for the distinct ID. May not be empty.
+     * @param alias      Alias to set for the distinct ID. May not be empty.
      */
     default void alias(@NotNull String distinctId, @NotNull String alias) {
         capture(distinctId, CREATE_ALIAS, Map.of(
@@ -205,8 +205,8 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
     /**
      * Assign the given properties to the given group (type &amp; key).
      *
-     * @param type Group type. Must not be empty
-     * @param key Group key. Must not be empty
+     * @param type       Group type. Must not be empty
+     * @param key        Group key. Must not be empty
      * @param properties Properties to set (including overwriting previous values) on the group
      */
     default void groupIdentify(@NotNull String type, @NotNull String key, @NotNull Map<String, Object> properties) {
@@ -218,8 +218,8 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
      *
      * <p>The object must be serializable to a JSON object via Gson (not primitive or array)</p>
      *
-     * @param type Group type. Must not be empty
-     * @param key Group key. Must not be empty
+     * @param type       Group type. Must not be empty
+     * @param key        Group key. Must not be empty
      * @param properties Properties to set (including overwriting previous values) on the group
      */
     default void groupIdentify(@NotNull String type, @NotNull String key, @NotNull Object properties) {
@@ -243,7 +243,7 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
     /**
      * Check if the given feature flag is enabled for the given distinct ID.
      *
-     * @param key Feature flag key
+     * @param key        Feature flag key
      * @param distinctId Unique ID of the target in your database. May not be empty
      * @return True if the feature flag is enabled for the given distinct ID, false otherwise
      */
@@ -254,9 +254,9 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
     /**
      * Check if the given feature flag is enabled for the given distinct ID with extra context.
      *
-     * @param key Feature flag key
+     * @param key        Feature flag key
      * @param distinctId Unique ID of the target in your database. May not be empty
-     * @param context Extra context to pass to the feature flag evaluation
+     * @param context    Extra context to pass to the feature flag evaluation
      * @return True if the feature flag is enabled for the given distinct ID, false otherwise
      */
     default boolean isFeatureEnabled(@NotNull String key, @NotNull String distinctId, @Nullable FeatureFlagContext context) {
@@ -266,7 +266,7 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
     /**
      * Get the feature flag state for the given distinct ID.
      *
-     * @param key Feature flag key
+     * @param key        Feature flag key
      * @param distinctId Unique ID of the target in your database. May not be empty
      * @return Feature flag state
      */
@@ -277,9 +277,9 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
     /**
      * Get the feature flag state for the given distinct ID with extra context.
      *
-     * @param key Feature flag key
+     * @param key        Feature flag key
      * @param distinctId Unique ID of the target in your database. May not be empty
-     * @param context Extra context to pass to the feature flag evaluation
+     * @param context    Extra context to pass to the feature flag evaluation
      * @return Feature flag state
      */
     @NotNull FeatureFlagState getFeatureFlag(@NotNull String key, @NotNull String distinctId, @Nullable FeatureFlagContext context);
@@ -287,7 +287,7 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
     /**
      * Get the feature flag payload for the given distinct ID.
      *
-     * @param key Feature flag key
+     * @param key        Feature flag key
      * @param distinctId Unique ID of the target in your database. May not be empty
      * @return Feature flag payload, or null if the feature flag is disabled <i>or</i> has no payload configured.
      */
@@ -298,9 +298,9 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
     /**
      * Get the feature flag payload for the given distinct ID.
      *
-     * @param key Feature flag key
+     * @param key        Feature flag key
      * @param distinctId Unique ID of the target in your database. May not be empty
-     * @param context Extra context to pass to the feature flag evaluation
+     * @param context    Extra context to pass to the feature flag evaluation
      * @return Feature flag payload, or null if the feature flag is disabled <i>or</i> has no payload configured.
      */
     default @Nullable String getFeatureFlagPayload(@NotNull String key, @NotNull String distinctId, @Nullable FeatureFlagContext context) {
@@ -321,7 +321,7 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
      * Get all feature flags for the given distinct ID with extra context.
      *
      * @param distinctId Unique ID of the target in your database. May not be empty
-     * @param context Extra context to pass to the feature flag evaluation
+     * @param context    Extra context to pass to the feature flag evaluation
      * @return Feature flag states
      */
     @NotNull FeatureFlagStates getAllFeatureFlags(@NotNull String distinctId, @Nullable FeatureFlagContext context);
@@ -333,6 +333,19 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
      * @throws IllegalStateException if local feature flag evaluation is not enabled.
      */
     void reloadFeatureFlags();
+
+    /**
+     * Blocks until local feature flags have been fetched, or the timeout is reached.
+     *
+     * <p>This is useful during application startup to ensure feature flags are available
+     * before accepting requests. If it fails, local evals are disabled until it re-fetches (and it succeeds).
+     *
+     * @param timeout Maximum time to wait for the fetch to complete
+     * @return true if feature flags were successfully loaded, false if the fetch failed or timed out
+     * @throws UnsupportedOperationException if local feature flag evaluation is not enabled
+     */
+    @Blocking
+    boolean awaitFeatureFlags(@NotNull Duration timeout);
 
 
     // Exceptions

--- a/src/main/java/net/hollowcube/posthog/PostHogClient.java
+++ b/src/main/java/net/hollowcube/posthog/PostHogClient.java
@@ -383,6 +383,7 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
         private boolean sendFeatureFlagEvents = false;
         private Duration featureFlagsPollingInterval = Duration.ofMinutes(5);
         private Duration featureFlagsRequestTimeout = Duration.ofSeconds(3);
+        private Duration blockUntilLocalFlagsLoaded = null;
 
         private BiFunction<Throwable, JsonObject, Boolean> exceptionMiddleware = null;
 
@@ -458,6 +459,24 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
             return this;
         }
 
+        /**
+         * Block during client construction until local feature flags have been fetched.
+         *
+         * <p>This ensures feature flags are available immediately after the client is built.
+         * If the fetch fails or times out, construction still succeeds but feature flag
+         * evaluations will return {@link FeatureFlagState#DISABLED} until the next successful fetch.</p>
+         *
+         * <p>Requires a personal API key to be set via {@link #personalApiKey(String)}.</p>
+         *
+         * @param timeout Maximum time to wait for the fetch to complete
+         * @return this builder
+         */
+        @Contract(pure = true)
+        public @NotNull Builder blockUntilLocalFlagsLoaded(@NotNull Duration timeout) {
+            this.blockUntilLocalFlagsLoaded = Objects.requireNonNull(timeout);
+            return this;
+        }
+
         @Contract(pure = true)
         public @NotNull Builder exceptionMiddleware(@NotNull BiFunction<Throwable, JsonObject, Boolean> exceptionMiddleware) {
             this.exceptionMiddleware = Objects.requireNonNull(exceptionMiddleware);
@@ -483,7 +502,7 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
                     .disableJdkUnsafe()
                     .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                     .create());
-            return new PostHogClientImpl(
+            var client = new PostHogClientImpl(
                     gson,
                     endpoint, projectApiKey, personalApiKey, // API
                     flushInterval, maxBatchSize, defaultEventProperties, // Events
@@ -492,6 +511,10 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
                     featureFlagsPollingInterval, featureFlagsRequestTimeout,
                     exceptionMiddleware // Exceptions
             );
+            if (blockUntilLocalFlagsLoaded != null) {
+                client.awaitFeatureFlags(blockUntilLocalFlagsLoaded);
+            }
+            return client;
         }
     }
 

--- a/src/main/java/net/hollowcube/posthog/PostHogClient.java
+++ b/src/main/java/net/hollowcube/posthog/PostHogClient.java
@@ -339,13 +339,27 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
      *
      * <p>This is useful during application startup to ensure feature flags are available
      * before accepting requests. If it fails, local evals are disabled until it re-fetches (and it succeeds).
+     * <p>
+     * Uses the timeout of {@link #loadRemoteFeatureFlags(Duration)}
+     *
+     * @return true if feature flags were successfully loaded, false if the fetch failed or timed out
+     * @throws UnsupportedOperationException if local feature flag evaluation is not enabled
+     */
+    @Blocking
+    boolean loadRemoteFeatureFlags();
+
+    /**
+     * Blocks until local feature flags have been fetched, or the timeout is reached.
+     *
+     * <p>This is useful during application startup to ensure feature flags are available
+     * before accepting requests. If it fails, local evals are disabled until it re-fetches (and it succeeds).
      *
      * @param timeout Maximum time to wait for the fetch to complete
      * @return true if feature flags were successfully loaded, false if the fetch failed or timed out
      * @throws UnsupportedOperationException if local feature flag evaluation is not enabled
      */
     @Blocking
-    boolean awaitFeatureFlags(@NotNull Duration timeout);
+    boolean loadRemoteFeatureFlags(@NotNull Duration timeout);
 
 
     // Exceptions
@@ -512,7 +526,7 @@ public sealed interface PostHogClient permits PostHogClientImpl, PostHogClientNo
                     exceptionMiddleware // Exceptions
             );
             if (blockUntilLocalFlagsLoaded != null) {
-                client.awaitFeatureFlags(blockUntilLocalFlagsLoaded);
+                client.loadRemoteFeatureFlags(blockUntilLocalFlagsLoaded);
             }
             return client;
         }

--- a/src/main/java/net/hollowcube/posthog/PostHogClientImpl.java
+++ b/src/main/java/net/hollowcube/posthog/PostHogClientImpl.java
@@ -50,6 +50,7 @@ public final class PostHogClientImpl implements PostHogClient {
 
     private Map<String, FeatureFlagsResponse.Flag> featureFlags = null; // Null until first fetch
     private final Map<String, Object> recentlyCapturedFeatureFlags = new ConcurrentHashMap<>();
+    private volatile boolean warnedAboutMissingFlags = false;
     private final boolean allowRemoteFeatureFlagEvaluation;
     private final boolean sendFeatureFlagEvents;
     private final Duration featureFlagsRequestTimeout;
@@ -205,6 +206,12 @@ public final class PostHogClientImpl implements PostHogClient {
         // This occurs when local flags are not loaded and remote eval is disabled, so we return disabled
         // If a client wants, they can block until local values are loaded with PostHogClient#awaitFeatureFlags
         if (result == null) {
+            if (!warnedAboutMissingFlags) {
+                warnedAboutMissingFlags = true;
+                log.warn("Local feature flags not yet loaded and remote evaluation is disabled. " +
+                        "Returning DISABLED for all flags until loaded. " +
+                        "Use awaitFeatureFlags() or blockUntilLocalFlagsLoaded() to avoid this.");
+            }
             return FeatureFlagState.DISABLED;
         }
 

--- a/src/main/java/net/hollowcube/posthog/PostHogClientImpl.java
+++ b/src/main/java/net/hollowcube/posthog/PostHogClientImpl.java
@@ -283,21 +283,16 @@ public final class PostHogClientImpl implements PostHogClient {
         this.featureFlagFetchTimer.wakeup();
     }
 
-    @Override
-    public boolean awaitFeatureFlags(@NotNull Duration timeout) {
-        if (this.personalApiKey == null)
+    @Blocking
+    public boolean loadRemoteFeatureFlags() {
+        return this.loadRemoteFeatureFlags(featureFlagsRequestTimeout);
+    }
+
+    @Blocking
+    public boolean loadRemoteFeatureFlags(@NotNull Duration timeout) {
+        if (this.personalApiKey == null) {
             throw new UnsupportedOperationException("Local feature flag evaluation is not enabled (no personal API key)");
-        return loadRemoteFeatureFlags(timeout);
-    }
-
-    @Blocking
-    private void loadRemoteFeatureFlags() {
-        loadRemoteFeatureFlags(featureFlagsRequestTimeout);
-    }
-
-    @Blocking
-    private boolean loadRemoteFeatureFlags(@NotNull Duration timeout) {
-        if (this.personalApiKey == null) return false; // Sanity check
+        }
 
         final HttpRequest req = HttpRequest.newBuilder(URI.create(String.format("%s/api/feature_flag/local_evaluation", endpoint)))
                 .header("Authorization", String.format("Bearer %s", this.personalApiKey))

--- a/src/main/java/net/hollowcube/posthog/PostHogClientImpl.java
+++ b/src/main/java/net/hollowcube/posthog/PostHogClientImpl.java
@@ -204,13 +204,13 @@ public final class PostHogClientImpl implements PostHogClient {
         }
 
         // This occurs when local flags are not loaded and remote eval is disabled, so we return disabled
-        // If a client wants, they can block until local values are loaded with PostHogClient#awaitFeatureFlags
+        // If a client wants, they can block until local values are loaded with PostHogClient#loadRemoteFeatureFlags
         if (result == null) {
             if (!warnedAboutMissingFlags) {
                 warnedAboutMissingFlags = true;
                 log.warn("Local feature flags not yet loaded and remote evaluation is disabled. " +
                         "Returning DISABLED for all flags until loaded. " +
-                        "Use awaitFeatureFlags() or blockUntilLocalFlagsLoaded() to avoid this.");
+                        "Use loadRemoteFeatureFlags() or blockUntilLocalFlagsLoaded() to avoid this.");
             }
             return FeatureFlagState.DISABLED;
         }

--- a/src/main/java/net/hollowcube/posthog/PostHogClientImpl.java
+++ b/src/main/java/net/hollowcube/posthog/PostHogClientImpl.java
@@ -202,6 +202,12 @@ public final class PostHogClientImpl implements PostHogClient {
             }
         }
 
+        // This occurs when local flags are not loaded and remote eval is disabled, so we return disabled
+        // If a client wants, they can block until local values are loaded with PostHogClient#awaitFeatureFlags
+        if (result == null) {
+            return FeatureFlagState.DISABLED;
+        }
+
         // Send feature flag called event if configured to do so.
         final boolean sendCalledEvent = featureFlagContext.sendFeatureFlagEvents() != null
                 ? featureFlagContext.sendFeatureFlagEvents()
@@ -270,19 +276,32 @@ public final class PostHogClientImpl implements PostHogClient {
         this.featureFlagFetchTimer.wakeup();
     }
 
+    @Override
+    public boolean awaitFeatureFlags(@NotNull Duration timeout) {
+        if (this.personalApiKey == null)
+            throw new UnsupportedOperationException("Local feature flag evaluation is not enabled (no personal API key)");
+        return loadRemoteFeatureFlags(timeout);
+    }
+
     @Blocking
     private void loadRemoteFeatureFlags() {
-        if (this.personalApiKey == null) return; // Sanity check
+        loadRemoteFeatureFlags(featureFlagsRequestTimeout);
+    }
+
+    @Blocking
+    private boolean loadRemoteFeatureFlags(@NotNull Duration timeout) {
+        if (this.personalApiKey == null) return false; // Sanity check
 
         final HttpRequest req = HttpRequest.newBuilder(URI.create(String.format("%s/api/feature_flag/local_evaluation", endpoint)))
                 .header("Authorization", String.format("Bearer %s", this.personalApiKey))
                 .header("User-Agent", USER_AGENT)
-                .timeout(featureFlagsRequestTimeout)
+                .timeout(timeout)
                 .build();
         try {
             final HttpResponse<String> res = this.httpClient.send(req, HttpResponse.BodyHandlers.ofString());
             if (res.statusCode() != 200) {
                 log.error("unexpected response from /api/feature_flag/local_evaluation ({}): {}", res.statusCode(), res.body());
+                return false;
             }
 
             final FeatureFlagsResponse resBody = this.gson.fromJson(res.body(), FeatureFlagsResponse.class);
@@ -291,13 +310,17 @@ public final class PostHogClientImpl implements PostHogClient {
                 newFeatureFlags.put(flag.key(), flag);
             }
             this.featureFlags = Map.copyOf(newFeatureFlags);
+            return true;
         } catch (InterruptedException ignored) {
             // Do nothing just exit
+            return false;
         } catch (HttpTimeoutException e) {
             log.warn("timed out making /api/feature_flag/local_evaluation request", e);
+            return false;
         } catch (Exception e) {
             // Catch everything because we do not want the timer itself to stop running.
             log.error("failed to make /api/feature_flag/local_evaluation request", e);
+            return false;
         }
     }
 

--- a/src/main/java/net/hollowcube/posthog/PostHogClientNoop.java
+++ b/src/main/java/net/hollowcube/posthog/PostHogClientNoop.java
@@ -38,7 +38,12 @@ final class PostHogClientNoop implements PostHogClient {
     }
 
     @Override
-    public boolean awaitFeatureFlags(@NotNull Duration timeout) {
+    public boolean loadRemoteFeatureFlags() {
+        return true;
+    }
+
+    @Override
+    public boolean loadRemoteFeatureFlags(@NotNull Duration timeout) {
         return true;
     }
 

--- a/src/main/java/net/hollowcube/posthog/PostHogClientNoop.java
+++ b/src/main/java/net/hollowcube/posthog/PostHogClientNoop.java
@@ -38,6 +38,11 @@ final class PostHogClientNoop implements PostHogClient {
     }
 
     @Override
+    public boolean awaitFeatureFlags(@NotNull Duration timeout) {
+        return true;
+    }
+
+    @Override
     public void captureException(@NotNull Throwable throwable, @Nullable String distinctId, @Nullable Object properties) {
         
     }


### PR DESCRIPTION
Currently, when using local eval (especially exclusively), you can encounter errors if you immediately use the client as local feature flags are loaded async in the background.

This PR adds a `loadRemoteFeatureFlags` method to the client + a subsequent builder option that retrieves and blocks until it has done so, allowing developers to block until the client is _actually_ ready.

Additionally, a check for the result being `null` has been added and warns (once) if such. This might be a desired situation for some.